### PR TITLE
Adds react 16.x and react-dom 16.x as peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,11 @@
   },
   "dependencies": {
     "clone": "^2.1.1",
-    "deep-is": "^0.1.3",
-    "react": "^15.5.4"
+    "deep-is": "^0.1.3"
+  },
+  "peerDependencies": {
+    "react": "^16.0.0 || ^15.5.4",
+    "react-dom": "^16.0.0 || ^15.5.4"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",
@@ -50,6 +53,7 @@
     "husky": "^0.14.3",
     "lint-staged": "^4.0.3",
     "prettier": "^1.5.3",
+    "react": "^15.5.4",
     "react-dom": "^15.5.4",
     "style-loader": "^0.17.0",
     "webpack": "^2.4.1",


### PR DESCRIPTION
Needed for migrating projects which use react-table-drag-select to React 16.x not to keep both React 15.x and React 16.x in a bundle.