### PR TITLE
More verbose error messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ export default class TableDragSelect extends React.Component {
         return; // Let error be handled elsewhere
       }
       const error = new Error(
-        "Invalid prop `children` supplied to `TableDragSelect`. Validation failed."
+        "Invalid prop `children` supplied to `TableDragSelect`. Validation failed.\n[Hint] Ensure the number of elements of the array passed to the `value` prop is equivalent to the number of cells passed as children."
       );
       const trs = React.Children.toArray(props.children);
       const rowCount = props.value.length;


### PR DESCRIPTION
Hi! Love the component.

I make the mistake of having miss-matched `value` and `children` props often and I feel the error message in its current form doesn't really assist in solving the error (I had to read the code the first time in order to solve it).

This adds a hint suggesting a resolution to the issue. Feel free to reword if needed.

Thanks 😄